### PR TITLE
Remove duplicate scope in python exception color

### DIFF
--- a/themes/Sublette-color-theme.json
+++ b/themes/Sublette-color-theme.json
@@ -924,13 +924,6 @@
             }
         },
         {
-            "name": "Python: Support.exception",
-            "scope": "support.type.exception.python",
-            "settings": {
-                "foreground": "#4ee"
-            }
-        },
-        {
             "name": "Ruby: Special Method",
             "scope": "keyword.other.special-method.ruby",
             "settings": {


### PR DESCRIPTION
Just as last PR review pointed out by @minmul117 