### PR TITLE
Remove deprecated items and improve readability in command palette

### DIFF
--- a/themes/Sublette-color-theme.json
+++ b/themes/Sublette-color-theme.json
@@ -45,10 +45,9 @@
         "badge.background": "#405570",
         // Lists and Trees — Colors for list and trees like the File Explorer. An active list/tree has keyboard focus, an inactive does not.
         "list.activeSelectionBackground": "#58f",
-        "list.activeSelectionForeground": "#202535",
         "list.dropBackground": "#202535",
-        "list.focusBackground": "#4ee",
-        "list.focusForeground": "#202535",
+        "quickInputList.focusBackground": "#202035",
+        "list.focusForeground": "#4ee",
         "list.hoverBackground": "#202535",
         "list.hoverForeground": "#ccced0",
         "list.inactiveSelectionBackground": "#347",
@@ -56,7 +55,7 @@
         "list.inactiveFocusBackground": "#356",
         // Activity Bar — The Activity Bar is displayed either on the far left or right of the workbench and allows fast switching between views of the Side Bar.
         "activityBar.background": "#202535",
-        "activityBar.dropBackground": "#405570",
+        "activityBar.dropBorder": "#405570",
         "activityBar.foreground": "#96a0aa",
         "activityBar.border": "#202535",
         "activityBarBadge.background": "#e57",
@@ -175,7 +174,7 @@
         // Panel Colors — Panels are shown below the editor area and contain views like Output and Integrated Terminal.
         "panel.background": "#202535",
         "panel.border": "#58f",
-        "panel.dropBackground": "#253045",
+        "panel.dropBorder": "#253045",
         "panelTitle.activeBorder": "#58f",
         "panelTitle.activeForeground": "#ccced0",
         "panelTitle.inactiveForeground": "#96a0aa",
@@ -453,7 +452,7 @@
                 "foreground": "#ccced0ff",
             }
         },
-        
+
         {
             "name": "Parameter",
             "scope": [
@@ -949,7 +948,7 @@
                 "foreground": "#e57"
             }
         },
-        
+
         {
             "name": "Shell: meta scope in loop",
             "scope": [


### PR DESCRIPTION
* Change for readability
    - `list.activitySelectionForeground`
    - `list.focusForeground`

* Removal of deprecated item
    - `list.focusBackground` -> `quickItemList.focusBackground`([#118214](https://github.com/microsoft/vscode/issues/118214))
        - ~~`quickItem.list` will be migrated into `quickItemList` in next release [Link](https://github.com/microsoft/vscode/issues/118214#issue-823131874)~~
    - `activityBar.dropBackground` -> `acitivityBar.dropBorder` ([#100239](https://github.com/microsoft/vscode/issues/100239))
    - `panel.dropBorder` -> `panel.dropBorder` ([#100239](https://github.com/microsoft/vscode/issues/100239))

| Before                 | After          |
|--------------------|--------------------|
| <img src=https://user-images.githubusercontent.com/156580/110873441-197b6080-8315-11eb-800e-93bfe15e5e94.png width="250"/> | <img src=https://user-images.githubusercontent.com/156580/110873474-2c8e3080-8315-11eb-9c32-c46955c5618d.png width="250"/>|